### PR TITLE
fix: omnibox parsing error on barcodes

### DIFF
--- a/js/app/Omnibox.html
+++ b/js/app/Omnibox.html
@@ -191,8 +191,13 @@ app.omnibox = {
         );
         manualEntryAlert();
       } else if (barcoderegex.test(value)) { // assume it's a barcode
-        parsed = app.cache.items.find(
-          item => item.barcode.toLowerCase() == value
+        parsed = app.cache.items.find(item => {
+            if (! item.barcode) {
+              return false
+            }
+            const barcode = "" + item.barcode
+            return barcode.toLowerCase() == value
+          }
         );
       }
       if (parsed) {


### PR DESCRIPTION
This bug appeared when changing over to the real inventory spreadsheet
which is does not always return barcodes as strings.  This fix
just makes sure the barcode key exists and is type string before
proceeding.

fixes issue #10