### PR TITLE
fix: updates `currentFormstack` for new forms

### DIFF
--- a/js/Display.html
+++ b/js/Display.html
@@ -172,6 +172,7 @@ function displayNewForm() {
   };
   const length = app.cache.openForms.push(app.cache.savedForm);
   app.cache.currentIndex = length - 1;
+  app.cache.currentFormstack = app.strings.formstack.openForms;
   displayForm(app.cache.savedForm);
 }
 


### PR DESCRIPTION
Assumes that requesting a "new form" implies you want the context to
be the open form stack.  Fixes a bug where opening a "new form" from the
closed forms context showed the form stack index for the closed forms.

fixes issue #47