### PR TITLE
Hotfix/combo44 46

### DIFF
--- a/html/Archive.html
+++ b/html/Archive.html
@@ -30,6 +30,9 @@
     <label for="items">Items</label>
     <input type="text" name="items" />
     <br>
+    <label for="matchAllItems">Match with All Items</label>
+    <input type="checkbox" name="matchAllItems" checked />
+    <br>
     Show Only Session Type:
     <br>
     <label for="booked">Booked Sessions</label>

--- a/js/Display.html
+++ b/js/Display.html
@@ -380,7 +380,108 @@ function populateStudentList(student) {
   ));
 }
 
-function displayArchivedForms(forms) {
+function displayArchivedForms(forms, sortBy) {
+  if (!sortBy) {
+    sortBy = app.pages.archive.sortBy;
+  } else {
+    app.pages.openForms.sortBy = sortBy;
+  }
+  let compare;
+  switch (sortBy) {
+    case 'startTime':
+    case 'endTime':
+      compare = function(a,b) {
+        let dateA = utility.date.parseFormattedDate(a[sortBy]).getTime(),
+            dateB = utility.date.parseFormattedDate(b[sortBy]).getTime();
+        if (dateA < dateB) {
+          return -1;
+        }
+        if (dateA > dateB) {
+          return 1;
+        }
+        if (dateA == dateB) {
+          return 0;
+        }
+      };
+      break;
+    case 'location':
+      compare = function(a,b) {
+        if (a[sortBy] < b[sortBy]) {
+          return -1;
+        }
+        if (a[sortBy] > b[sortBy]) {
+          return 1;
+        }
+        if (a[sortBy] == b[sortBy]) {
+          return 0;
+        }
+      };
+      break;
+    case 'contact':
+    case 'tape':
+    case 'overnight':
+    case 'items':
+    case 'project':
+    case 'bookingId':
+    compare = function(a,b) {
+        if (a[sortBy] < b[sortBy]) {
+          return -1;
+        }
+        if (a[sortBy] > b[sortBy]) {
+          return 1;
+        }
+        if (a[sortBy] == b[sortBy]) {
+          return 0;
+        }
+      };
+      break;
+    case 'bookedStudents':
+    case 'students':
+      compare = function(a,b) {
+        let nameSort = function(c,d) {
+          if (c.name < d.name) {
+            return -1;
+          }
+          if (c.name > d.name) {
+            return 1;
+          }
+          if (c.name == d.name) {
+            return 0;
+          }
+        };
+        a.students.sort(nameSort);
+        b.students.sort(nameSort);
+        if (a.students[0].name < b.students[0].name) {
+          return -1;
+        }
+        if (a.students[0].name > b.students[0].name) {
+          return 1;
+        }
+        if (a.students[0].name == b.students[0].name) {
+          return 0;
+        }
+      };
+      break;
+    case 'type':
+      compare = function(a,b) {
+        let active = function(student) {
+          return student.checkIn;
+        };
+        a = +(a.students.some(active));
+        b = +(b.students.some(active));
+        if (a > b) {
+          return -1;
+        }
+        if (a < b) {
+          return 1;
+        }
+        if (a == b) {
+          return 0;
+        }
+      };
+      break;
+  }
+  forms.sort(compare);
   populateArchiveTable(forms);
 }
 

--- a/js/Init.html
+++ b/js/Init.html
@@ -42,7 +42,7 @@ app.pages.form.elements.container.addEventListener(
 app.pages.form.elements.container.addEventListener(
   'click', app.pages.form.handleClickTable
 );
-// focus guards create a tab/shift-tab closed loop through the form inputs 
+// focus guards create a tab/shift-tab closed loop through the form inputs
 app.pages.form.elements.focusGuardTop.addEventListener(
   'focus', () => app.pages.form.elements.locationSelect.focus()
 );

--- a/js/Init.html
+++ b/js/Init.html
@@ -28,6 +28,9 @@ app.pages.archive.elements.tableBody.addEventListener(
 app.pages.archive.elements.queryInputs.addEventListener(
   'change', app.pages.archive.handleChange
 );
+app.pages.archive.elements.tableHead.addEventListener(
+  'click', app.pages.archive.handleClickTableHead
+);
 
 // FORM (single view)
 app.pages.form.elements.container.addEventListener(

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -236,6 +236,11 @@ app.doCommand = function(command,...options) {
       displayOpenForms(app.cache.openForms, sortType);
       break;
     }
+    case 'sortArchivedForms': {
+      const sortType = options[0];
+      displayArchivedForms(app.cache.archive, sortType);
+      break;
+    }
     case 'studentNote': {
       const radio = app.modal.table.querySelectorAll('input[type="radio"]');
       let value;

--- a/js/app/Refresh.html
+++ b/js/app/Refresh.html
@@ -129,6 +129,6 @@ app.refresh = function(response, context) {
       app.elements.usernameDisplay.textContent = response.user;
       break;
   }
-  
+
 };
 </script>

--- a/js/app/Refresh.html
+++ b/js/app/Refresh.html
@@ -25,6 +25,7 @@ app.refresh = function(response, context) {
       }
       app.cache.archive = JSON.parse(response.formList);
       app.pages.archive.query();
+      displayArchivedForms(app.cache.archive);
       break;
     case 'checkForms': {
       const newForms = JSON.parse(response.formList);

--- a/js/app/pages/Archive.html
+++ b/js/app/pages/Archive.html
@@ -87,6 +87,7 @@ app.pages.archive = {
     let startRange   = new Date(inputs.start.value + 'T00:00:00'),
         endRange     = new Date(inputs.end.value  + 'T23:59:59'),
         itemQuery    = inputs.items.value,
+        itemDescQuery = inputs.items.value.toLowerCase().split(','),
         studentQuery = inputs.students.value,
         cleanStudent = function(value, index, array) {
           array[index] = array[index].replace(/\s/g, '');
@@ -160,8 +161,16 @@ app.pages.archive = {
             });
           });
           if (!found) {
+            let found = itemDescQuery.find(queryArg => {
+              return form.items.find(item => {
+                let itemDesc = item.description.toLowerCase();
+                  return (itemDesc.search(queryArg) > -1);
+                
+              });
+            });
+          if (!found) {
             return false;
-          }
+          }}
         }
 
         // filter by errors

--- a/js/app/pages/Archive.html
+++ b/js/app/pages/Archive.html
@@ -152,25 +152,37 @@ app.pages.archive = {
           }
         }
 
-        // filter by item id
-        if (inputs.items.value) {
+        // filter by match all item id
+        if (inputs.items.value && inputs.matchAllItems.checked) {
+          let count = 0; //counts how many matches we have had
+          itemQuery.forEach(function(queryArg) {
+            let ran=false; //resets the ran flag
+            form.items.forEach(function(item){
+              let itemId = item.id.toLowerCase().replace(/-0+/, '-'); //cleans up the item id to compare
+              let itemDesc = item.description.toLowerCase();
+                if ((itemId.search(queryArg) > -1 || itemDesc.search(queryArg) > -1) && !ran){ //if the id matches, increment count
+                    count++;
+                    ran=true;
+              }
+            })
+          })
+        return count >= itemQuery.length;
+        }
+
+        // filter by match any item id
+        if (inputs.items.value && !inputs.matchAllItems.checked) {
           let found = itemQuery.find(queryArg => {
             return form.items.find(item => {
+              let itemDesc = item.description.toLowerCase();
               let itemId = item.id.toLowerCase().replace(/-0+/, '-');
-              return (itemId.search(queryArg) > -1);
+              if (itemId.search(queryArg) > -1 || itemDesc.search(queryArg) > -1){
+                return true
+              }
             });
           });
           if (!found) {
-            let found = itemDescQuery.find(queryArg => {
-              return form.items.find(item => {
-                let itemDesc = item.description.toLowerCase();
-                  return (itemDesc.search(queryArg) > -1);
-                
-              });
-            });
-          if (!found) {
             return false;
-          }}
+          }
         }
 
         // filter by errors

--- a/js/app/pages/Archive.html
+++ b/js/app/pages/Archive.html
@@ -7,6 +7,7 @@ app.pages.archive = {
     queryCount:  document.querySelector('span.querycount'),
     queryInputs: document.querySelector('form.query'),
     tableBody:   document.querySelector('tbody.archive'),
+    tableHead:   document.querySelector('thead.archive'),
   },
   handleChange: function(change) {
     if (change.target.getAttribute('type') == 'date') {
@@ -49,6 +50,9 @@ app.pages.archive = {
     }
     app.cache.currentIndex = index;
     app.doCommand('displayForm', app.cache.archive[index], true);
+  },
+  handleClickTableHead: function(click) {
+    app.doCommand('sortArchivedForms', click.target.dataset.sort);
   },
   getDateRangeAsJSON: function() {
     let inputs = app.pages.archive.elements.queryInputs;

--- a/js/app/pages/Archive.html
+++ b/js/app/pages/Archive.html
@@ -86,7 +86,7 @@ app.pages.archive = {
     }
     let startRange   = new Date(inputs.start.value + 'T00:00:00'),
         endRange     = new Date(inputs.end.value  + 'T23:59:59'),
-        itemQuery    = inputs.items.value, 
+        itemQuery    = inputs.items.value,
         studentQuery = inputs.students.value,
         cleanStudent = function(value, index, array) {
           array[index] = array[index].replace(/\s/g, '');
@@ -113,7 +113,7 @@ app.pages.archive = {
             (start.getTime() >= endRange.getTime())) {
           return false;
         }
-        
+
         // filter by location
         if (inputs.location.value != 'All') {
           if (inputs.location.value != 'Other') {
@@ -126,7 +126,7 @@ app.pages.archive = {
             }
           }
         }
-  
+
         // filter by booked/not booked, tape
         if (!inputs.booked.checked && form.bookingId) {
           return false;
@@ -137,7 +137,7 @@ app.pages.archive = {
         if (inputs.tape.checked && !form.tape) {
           return false;
         }
-  
+
         // filter by student names
         if (inputs.students.value) {
           let found = studentQuery.find(queryArg => {
@@ -150,7 +150,7 @@ app.pages.archive = {
             return false;
           }
         }
-  
+
         // filter by item id
         if (inputs.items.value) {
           let found = itemQuery.find(queryArg => {
@@ -163,7 +163,7 @@ app.pages.archive = {
             return false;
           }
         }
-  
+
         // filter by errors
         // filter by manual entry
         if (inputs.manual.checked) {
@@ -186,14 +186,14 @@ app.pages.archive = {
             return false;
           }
         }
-  
+
         // filter by global notes
         if (inputs.notes.checked) {
           if (form.notes.length == 0) {
             return false;
           }
         }
-        
+
         // filter by late students
         if (inputs.late.checked) {
           const gracePeriod = 15; // minutes
@@ -201,7 +201,7 @@ app.pages.archive = {
               start = utility.date.parseFormattedDate(form.startTime),
               end   = utility.date.parseFormattedDate(form.endTime);
           start.setMinutes(start.getMinutes() + gracePeriod);
-          
+
           let checkedInOnTime = function(student) {
             if (!student.checkIn) {
               return true; // i.e. no show != late
@@ -210,7 +210,7 @@ app.pages.archive = {
               .getTime();
             return (checkIn <= start.getTime());
           };
-          
+
           let checkedOutLate = function(student) {
             if (student.checkIn && !student.checkOut) {
               return true; // checked-in student never checked-out
@@ -223,7 +223,7 @@ app.pages.archive = {
               return false;
             }
           };
-          
+
           // late check-ins
           if (!form.students.every(checkedInOnTime)) {
             found = true;
@@ -235,9 +235,9 @@ app.pages.archive = {
           if (!found) {
             return false;
           }
-          
+
         }
-        
+
         // filter by no show
         if (inputs.noshow.checked) {
           // check for some check-ins
@@ -245,7 +245,7 @@ app.pages.archive = {
             return false;
           }
         }
-  
+
         return true;
       });
     if (app.cache.archiveFiltered.length == 1) {
@@ -256,7 +256,7 @@ app.pages.archive = {
       app.pages.archive
         .elements.queryCount.textContent = app.cache.archiveFiltered
           .length + ' forms';
-    } 
+    }
     displayArchivedForms(app.cache.archiveFiltered);
   },
   range: {


### PR DESCRIPTION
feat: Add sorting to archive
                                                                                                                                                                                                        allows the forms within archive to be sorted in the same way that the forms in OpenForms can. Requested by Michael McCoy on 4/25/19
                                                                                                                                                                        fixes issue #44 


feat: Add "Match only forms with ALL items" to the archive search                                                                                                                                                              adds a checkbox toggle to switch between matching forms that include any items that were input and forms that include all items that were input.                                                                                                                                                                                                                                                                                                                                                          fixes issue #45


feat: add searching by item description (or partial description) to the                                                 archive filter

adds the ability to search by description in the archive as well as by ItemId 

fixes issue #46