### PR TITLE
fix: Double scanning non serialized items does not prompt for quantity

### DIFF
--- a/js/Logic.html
+++ b/js/Logic.html
@@ -53,7 +53,7 @@ function isCheckInItemOk(item) {
   if (! savedItem || ! savedItem.checkOut) {
     app.omnibox.clear();
     if (! item.serialized) {
-      app.modal.handleQuantityChange(item.id);
+      app.modal.handleQuantityChange(item.description);
       return false;
     }
     app.modal.handleError(


### PR DESCRIPTION
Double scanning non serialized items did not prompt for quantity because
js/Logic.html::isCheckInItemOK passed item.id to
app.modal.handleQuantityChange, but app.modal.handleQuantityChange takes
item.description since 5746187

fixes issue #56