### PR TITLE
fix: prevent archived forms from being modified

### DIFF
--- a/html/Form.html
+++ b/html/Form.html
@@ -19,7 +19,7 @@
       <div class="focusGuardTop" tabindex="0"></div>
       <input class="omnibox" type="text" placeholder="Scan ID or barcode" autocomplete="off"/>
       <button class="action buttonSmall" value="parseOmnibox" tabindex="-1">&#128269;</button>
-      <button class="action" value="parseOmnibox" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
+      <button class="action" value="manualItem" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
       <button class="action buttonNotes" value="newNote" tabindex="-1">New Note</button>
       <button value="changeLog" tabindex="-1">Change Log</button>
       <br />

--- a/js/Display.html
+++ b/js/Display.html
@@ -149,11 +149,15 @@ function displayForm(form, archived) {
   if (archived) {
     app.omnibox.element.setAttribute('disabled', true);
     app.pages.form.elements.newNoteButton.setAttribute('disabled', true);
+    app.pages.form.elements.manualButton.setAttribute('disabled', true);
+    app.pages.form.elements.omniboxButton.setAttribute('disabled', true);
     app.pages.form.elements.updateButtonHint.textContent = 'This is a closed form.  You cannot edit it.';
   } else {
     app.omnibox.element.removeAttribute('disabled');
     app.omnibox.element.focus();
     app.pages.form.elements.newNoteButton.removeAttribute('disabled');
+    app.pages.form.elements.manualButton.removeAttribute('disabled');
+    app.pages.form.elements.omniboxButton.removeAttribute('disabled');
     app.pages.form.elements.updateButtonHint.textContent = '';
   }
 
@@ -367,7 +371,7 @@ function populateItemList(item) {
     itemRow.classList.add('nonserialized');
   }
   app.pages.form.elements.itemList.appendChild(itemRow);
-  
+
   notes.setAttribute('colspan', 4);
   notes.classList.add('itemnotes');
   notes.textContent = item.notes;

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -157,6 +157,7 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
+    case 'manualItem':
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/main.html
+++ b/js/app/main.html
@@ -5,7 +5,7 @@
 const app = {
   cache:     {},                         // data container
   changes:   {},                         // log user changes
-  doCommand: function(/*command, ...options */){},// command switch block
+  doCommand: function(/* command, ...options */){},// command switch block
   elements:  {},                         // top level elements e.g. global navigation
   errors:    [],                         // error stack to ensure all errors get displayed to user
   handlers:  {},                         // event methods

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -16,6 +16,8 @@ app.pages.form = {
     locationSelect:          document.querySelector('form.model select[name="location"]'),
     locationOtherOption:     document.querySelector('form.model option[value="Other"]'),
     newNoteButton:           document.querySelector('button[value="newNote"]'),
+    manualButton:            document.querySelector('button[value="manualItem"]'),
+    omniboxButton:           document.querySelector('button[value="parseOmnibox"]'),
     noteSection:             document.querySelector('section.globalnotes'),
     studentList:             document.querySelector('tbody.studentList'),
     tableStaticFields:       document.querySelector('table.staticFields'),
@@ -156,7 +158,12 @@ app.pages.form = {
     app.changes.add(newChange);
   },
   handleClickItem: function(click) {
-    if (click.target.parentNode.classList.contains('itemnotes')) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
+    if (click.target.classList.contains('itemnotes')) {
+
       return;
     }
     if (click.metaKey) {
@@ -174,6 +181,10 @@ app.pages.form = {
     app.modal.handleItemNote(item);
   },
   handleClickTable: function(click) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
     if (click.target.tagName != 'TD') {
       return;
     }
@@ -241,6 +252,10 @@ app.pages.form = {
     app.omnibox.parse();
   },
   handleClickStudent: function(click) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
     if (click.metaKey) {
       return;
     }


### PR DESCRIPTION
exits item and student click handlers if the form is archived, and
disables the omnibox submit and manual entry buttons.

fixes issue #31