### PR TITLE
fix: show only global notes does not work in archive

### DIFF
--- a/html/Archive.html
+++ b/html/Archive.html
@@ -46,8 +46,11 @@
     <br>
     Show Only Error Type:
     <br>
-    <label for="incomplete">Incomplete Forms</label>
-    <input type="checkbox" name="incomplete" />
+    <label for="missingItem">Missing Item(s)</label>
+    <input type="checkbox" name="missingItem" />
+    <br>
+    <label for="studentLeft">Student(s) didn't check out</label>
+    <input type="checkbox" name="studentLeft" />
     <br>
     <label for="manual">Manual Entries</label>
     <input type="checkbox" name="manual" />

--- a/html/Form.html
+++ b/html/Form.html
@@ -19,7 +19,7 @@
       <div class="focusGuardTop" tabindex="0"></div>
       <input class="omnibox" type="text" placeholder="Scan ID or barcode" autocomplete="off"/>
       <button class="action buttonSmall" value="parseOmnibox" tabindex="-1">&#128269;</button>
-      <button class="action" value="parseOmnibox" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
+      <button class="action" value="manualItem" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
       <button class="action buttonNotes" value="newNote" tabindex="-1">New Note</button>
       <button value="changeLog" tabindex="-1">Change Log</button>
       <br />

--- a/js/Display.html
+++ b/js/Display.html
@@ -152,12 +152,16 @@ function displayForm(form, archived) {
   if (archived) {
     app.omnibox.element.setAttribute('disabled', true);
     app.pages.form.elements.newNoteButton.setAttribute('disabled', true);
+    app.pages.form.elements.manualButton.setAttribute('disabled', true);
+    app.pages.form.elements.omniboxButton.setAttribute('disabled', true);
     app.pages.form.elements
       .updateButtonHint.textContent = 'This is a closed form.  You cannot edit it.';
   } else {
     app.omnibox.element.removeAttribute('disabled');
     app.omnibox.element.focus();
     app.pages.form.elements.newNoteButton.removeAttribute('disabled');
+    app.pages.form.elements.manualButton.removeAttribute('disabled');
+    app.pages.form.elements.omniboxButton.removeAttribute('disabled');
     app.pages.form.elements.updateButtonHint.textContent = '';
   }
 
@@ -380,7 +384,7 @@ function populateItemList(item) {
     itemRow.classList.add('serialized');
   }
   app.pages.form.elements.itemList.appendChild(itemRow);
-  
+
   notes.setAttribute('colspan', 4);
   notes.classList.add('itemnotes');
   notes.textContent = 'Notes: ' + item.notes;

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -151,6 +151,7 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
+    case 'manualItem':
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -286,7 +286,7 @@ app.modal = {
     m.setStrings('itemNote');
     m.body.textContent = 'Item: ' + item.description;
     utility.DOM.empty(m.table);
-    if(!item.checkIn) {
+    if(!item.checkIn && !item.missing) {
       m.table.appendChild(
         utility.DOM.makeTableRow(
           'td', 'Item cannot be found', radio['missing']
@@ -334,7 +334,7 @@ app.modal = {
           'td', 'Student never showed up', radio['no show']
         )
       );
-    } else if (!student.checkOut) {
+    } else if (!student.checkOut && !student.left) {
       m.table.appendChild(
         utility.DOM.makeTableRow(
           'td', 'Student left without checking out', radio['left']

--- a/js/app/main.html
+++ b/js/app/main.html
@@ -5,7 +5,7 @@
 const app = {
   cache:     {},                         // data container
   changes:   {},                         // log user changes
-  doCommand: function(/*command, ...options */){},// command switch block
+  doCommand: function(/* command, ...options */){},// command switch block
   elements:  {},                         // top level elements e.g. global navigation
   errors:    [],                         // error stack to ensure all errors get displayed to user
   handlers:  {},                         // event methods

--- a/js/app/pages/Archive.html
+++ b/js/app/pages/Archive.html
@@ -191,25 +191,34 @@ app.pages.archive = {
         }
 
         // filter by errors
-        // filter by incomplete forms
-        if (inputs.incomplete.checked) {
+        // filter by forms with missing items
+        if (inputs.missingItem.checked) {
           let found = false;
-          checkIncompleteStudents: for (let student of form.students) {
-            if (student.left){
-              found = true;
-              break checkIncompleteStudents;
-            }
-          }
-          checkIncompleteItems: for (let item of form.items) {
+          checkMissingItem: for (let item of form.items) {
             if (item.missing){
               found = true;
-              break checkIncompleteItems;
+              break checkMissingItem;
             }
           }
           if (! found) {
             return false;
           }
         }
+
+        // filter by forms where students left without checking out
+        if (inputs.studentLeft.checked) {
+          let found = false;
+          checkStudentLeft: for (let student of form.students) {
+            if (student.left){
+              found = true;
+              break checkStudentLeft;
+            }
+          }
+          if (! found) {
+            return false;
+          }
+        }
+
         // filter by manual entry
         if (inputs.manual.checked) {
           let found = false;
@@ -234,9 +243,15 @@ app.pages.archive = {
 
         // filter by global notes
         if (inputs.notes.checked) {
-          if (form.notes.length == 0) {
-            return false;
+          let globalNotesExist = false;
+          for (let note of form.notes) {
+            try {                    // Unintuitive use of try/catch: read carefully:
+              JSON.parse(note.body); // (success == change log ) => ignore it
+            } catch(e) {             // (  error == global note) => increment the global note counter
+              globalNotesExist = true;
+            }
           }
+          return (globalNotesExist);
         }
 
         // filter by late students

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -16,6 +16,8 @@ app.pages.form = {
     locationSelect:          document.querySelector('form.model select[name="location"]'),
     locationOtherOption:     document.querySelector('form.model option[value="Other"]'),
     newNoteButton:           document.querySelector('button[value="newNote"]'),
+    manualButton:            document.querySelector('button[value="manualItem"]'),
+    omniboxButton:           document.querySelector('button[value="parseOmnibox"]'),
     noteSection:             document.querySelector('section.globalnotes'),
     studentList:             document.querySelector('tbody.studentList'),
     tableStaticFields:       document.querySelector('table.staticFields'),
@@ -157,6 +159,10 @@ app.pages.form = {
   },
 
   handleClickItem: function(click) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
     if (click.metaKey) {
       return;
     }
@@ -182,6 +188,10 @@ app.pages.form = {
     }
   },
   handleClickTable: function(click) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
     if (click.target.classList.contains('itemnotes')){
       return;
     }
@@ -237,6 +247,10 @@ app.pages.form = {
     app.omnibox.parse();
   },
   handleClickStudent: function(click) {
+    const isArchive = (app.cache.currentFormstack == 'archive') ? true : false;
+    if (isArchive){
+      return;
+    }
     if (click.metaKey) {
       return;
     }


### PR DESCRIPTION
fix: show only global notes does not work in archive

fixes the archive filter for "show only global notes"
splits "incomplete forms" filter into "Student(s) didn't check out" and "Missing Item(s)"

fixes issue #60