### PR TITLE
feat: Register new Codabar to a student when scanned

### DIFF
--- a/gs/Main.js
+++ b/gs/Main.js
@@ -100,7 +100,7 @@ function doPost(request) {
   // to update wasn't already updated by someone else.
   switch (request.post) {
     case 'codabar':
-      postCodabar_(request.netId, request.codabar, request.overwrite);
+      postCodabar_(request.netId, request.codabar, request.update);
       response.students = getAllStudents_();
       break;
     case 'signature':
@@ -301,11 +301,11 @@ function isValidForm_(form) {
   return form;
 }
 
-function postCodabar_(netId, codabar, overwrite) {
+function postCodabar_(netId, codabar, update) {
   var oldCodabar = readCodabarGAS_(netId);
   // if there isn't an old codabar, a codabar has been created since the creation of app.cache
-  // and shares the same value as the incoming change, or an overwrite has been approved
-  if (oldCodabar == '' || oldCodabar == codabar || overwrite){
+  // and shares the same value as the incoming change, or an update has been approved
+  if (oldCodabar == '' || oldCodabar == codabar || update){
     writeCodabarGAS_(netId, codabar);
   } else {
     // there must be an old codabar registered that wasn't registed when app.cache was created

--- a/gs/Main.js
+++ b/gs/Main.js
@@ -9,6 +9,7 @@ getArchivedFormsGAS_
 getOpenFormsGAS_
 startSignature_
 writeCodabarGAS_
+readCodabarGAS_
 writeFormToSheetGAS_
 writeSignatureToSheetGAS_
 */
@@ -99,7 +100,7 @@ function doPost(request) {
   // to update wasn't already updated by someone else.
   switch (request.post) {
     case 'codabar':
-      postCodabar_(request.netId, request.codabar);
+      postCodabar_(request.netId, request.codabar, request.overwrite);
       response.students = getAllStudents_();
       break;
     case 'signature':
@@ -300,8 +301,16 @@ function isValidForm_(form) {
   return form;
 }
 
-function postCodabar_(netId, codabar) {
-  writeCodabarGAS_(netId, codabar);
+function postCodabar_(netId, codabar, overwrite) {
+  var oldCodabar = readCodabarGAS_(netId);
+  // if there isn't an old codabar, a codabar has been created since the creation of app.cache
+  // and shares the same value as the incoming change, or an overwrite has been approved
+  if (oldCodabar == '' || oldCodabar == codabar || overwrite){
+    writeCodabarGAS_(netId, codabar);
+  } else {
+    // there must be an old codabar registered that wasn't registed when app.cache was created
+    throw new Error ('Codabar could not be written. Please save your form, refresh your browser, and try again');
+  }
 }
 
 /** @see doPost */

--- a/gs/Main.js
+++ b/gs/Main.js
@@ -9,7 +9,6 @@ getArchivedFormsGAS_
 getOpenFormsGAS_
 startSignature_
 writeCodabarGAS_
-readCodabarGAS_
 writeFormToSheetGAS_
 writeSignatureToSheetGAS_
 */
@@ -100,7 +99,7 @@ function doPost(request) {
   // to update wasn't already updated by someone else.
   switch (request.post) {
     case 'codabar':
-      postCodabar_(request.netId, request.codabar, request.update);
+      postCodabar_(request);
       response.students = getAllStudents_();
       break;
     case 'signature':
@@ -301,15 +300,19 @@ function isValidForm_(form) {
   return form;
 }
 
-function postCodabar_(netId, codabar, update) {
-  var oldCodabar = readCodabarGAS_(netId);
-  // if there isn't an old codabar, a codabar has been created since the creation of app.cache
-  // and shares the same value as the incoming change, or an update has been approved
-  if (oldCodabar == '' || oldCodabar == codabar || update){
-    writeCodabarGAS_(netId, codabar);
-  } else {
-    // there must be an old codabar registered that wasn't registed when app.cache was created
-    throw new Error ('Codabar could not be written. Please save your form, refresh your browser, and try again');
+/**
+ * @param {obj} request - .netId{string}, .codabar{string}, .update{bool}
+ */
+function postCodabar_(request) {
+  try {
+    writeCodabarGAS_(request.netId, request.codabar, request.update);
+  } catch (error) {
+    if (/ID EXISTS/.test(error)) {
+      throw new Error("Oops, we have another ID saved for " + request.netId +
+        ". Trying refreshing your browser."
+      );
+    }
+    throw error;
   }
 }
 

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -268,7 +268,14 @@ function getSheetDataByIdGAS_(value, sheetId, sheetName, idIndex) {
   var sheet = SpreadsheetApp.openById(sheetId).getSheetByName(sheetName);
   var data = sheet.getDataRange().getValues();
   data.shift();
-  return data.findRowContaining(value, idIndex);
+  var sheetData = data.findRowContaining(value, idIndex);
+  if (typeof sheetData == "undefined") {
+    throw new Error("could not find data for" +
+      " Value: " + value + ", Sheet ID: " + sheetId +
+     ", Sheet Name: " + sheetName + ", IDINDEX: " + idIndex
+    );
+  }
+  return sheetData;
 }
 
 /* ********* MAKERS *********** */
@@ -358,12 +365,10 @@ function writeCodabarGAS_(netId, codabar) {
     .getSheetByName(index.students.SHEET_NAME);
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(netId, index.students.NETID, true);
-  if (! i) {
-    // the the server called readCodabarGAS_, and the netId must have been removed since then
+  if (typeof i == "undefined") {
     throw new Error ('Could not write codabar for ' + netId);
-  } else {
-    sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
   }
+  sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
 }
 
 /* exported readCodabarGAS_ */
@@ -372,7 +377,7 @@ function readCodabarGAS_(netId) {
     .getSheetByName(index.students.SHEET_NAME);
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(netId, index.students.NETID, true);
-  if (! i) {
+  if (typeof i == "undefined") {
     // the netId existed when the local machine checked app.cache, and must have been removed since then
     throw new Error ('Could not find ' + netId);
   } else {
@@ -412,7 +417,7 @@ function writeFormToSheetGAS_(form, closeAndArchive) {
 
   // Note: do not shift data
   var index_ = data.findRowContaining(id, 0, true);
-  if (! index_) {
+  if (typeof index_ == "undefined") {
     throw 'could not find form ' + form;
   }
   var row = index_ + 1;
@@ -455,11 +460,10 @@ function writeSignatureToSheetGAS_(request) {
     .getSheetByName(index.students.SHEET_NAME);
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(request.id, index.students.NETID, true);
-  if (! i) {
+  if (typeof i == "undefined") {
     throw 'Could not match ' + request.id;
-  } else {
-    sheet.getRange(i + 1, index.students.SIGNATURE + 1).setValue(request.dataURL);
   }
+  sheet.getRange(i + 1, index.students.SIGNATURE + 1).setValue(request.dataURL);
 }
 
 /* exported startSignature_ */

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -6,7 +6,7 @@ utility
 Item_
 Student_
 */
-/********** GLOBAL VARIABLES ************/
+/* ********* GLOBAL VARIABLES *********** */
 var index = {
   bookings: {
     SHEET_ID   : '1zl4FBglYgCdR_FMdfbIQOOpnt9b8TwgnjxzRwcekPrY',
@@ -112,7 +112,7 @@ function checkItemsGAS_(form) {
   return form;
 }
 
-/********** CREATORS ************/
+/* ********* CREATORS *********** */
 
 /**
  * Loops createBookingFormGAS_ for each daily booking
@@ -138,7 +138,7 @@ function createBookingFormGAS_(booking) {
       itemStringArray = booking.getItems(),
       items = [],
       studentStringArray,
-      students = []; 
+      students = [];
 
   // handle booking students -> form students
   studentStringArray = bookedStudents.replace(/, /g, ',').split(',');
@@ -149,7 +149,7 @@ function createBookingFormGAS_(booking) {
     );
     students.push(makeStudentFromDataGAS_(data));
   });
-  
+
   // handle booking items -> form items
   if (itemStringArray) {
     itemStringArray = itemStringArray.split(',');
@@ -170,7 +170,7 @@ function createBookingFormGAS_(booking) {
       }
     });
   }
-  
+
   form.setBookedStudents(bookedStudents)
     .setBookingId(booking.getId())
     .setItems(items)
@@ -181,13 +181,13 @@ function createBookingFormGAS_(booking) {
     .setTape(booking.getTape())
     .setProject(booking.getProject())
     .setStudents(students);
-  
+
   writeFormToSheetGAS_(form);
-  
+
   return form;
 }
 
-/********** GETTERS ************/
+/* ********* GETTERS *********** */
 
 /* exported getAllItemsGAS_ */
 function getAllItemsGAS_() {
@@ -271,7 +271,7 @@ function getSheetDataByIdGAS_(value, sheetId, sheetName, idIndex) {
   return data.findRowContaining(value, idIndex);
 }
 
-/********** MAKERS ************/
+/* ********* MAKERS *********** */
 
 /**
  * @param {[]} bookingData
@@ -279,7 +279,7 @@ function getSheetDataByIdGAS_(value, sheetId, sheetName, idIndex) {
  */
 function makeBookingFromDataGAS_(bookingData) {
   var booking = new Booking_(bookingData[index.bookings.ID]);
-  
+
   booking.setBookedStudents(bookingData[index.bookings.STUDENTS])
     .setItems(bookingData[index.bookings.ITEMS])
     .setStartTime(utility.date.getFormattedDate(bookingData[index.bookings.START_TIME]))
@@ -288,17 +288,17 @@ function makeBookingFromDataGAS_(bookingData) {
     .setContact(bookingData[index.bookings.CONTACT])
     .setTape(bookingData[index.bookings.TAPE])
     .setProject(bookingData[index.bookings.PROJECT]);
-  
+
   return booking;
 }
 
-/** @param {object []} sheetData - a row pulled from Forms Sheet */ 
+/** @param {object []} sheetData - a row pulled from Forms Sheet */
 function makeFormFromDataGAS_(sheetData) {
   var form = new Form_(sheetData[index.forms.ID]),
       studentInfo = JSON.parse(sheetData[index.forms.STUDENTS]),
       itemsInfo = JSON.parse(sheetData[index.forms.ITEMS]),
       notes = JSON.parse(sheetData[index.forms.NOTES]);
-  
+
   form.setBookingId(sheetData[index.forms.BOOKING_ID])
     .setBookedStudents(sheetData[index.forms.BOOKED_STUDENTS])
     .setItems(itemsInfo)
@@ -311,14 +311,14 @@ function makeFormFromDataGAS_(sheetData) {
     .setStudents(studentInfo)
     .setNotes(notes)
     .setHash();
-  
+
   return form;
 }
 
 function makeItemFromDataGAS_(itemData) {
   var item = new Item_(itemData[index.items.ID]),
       description;
-  
+
   // Item has only a simple 'description' field
   // Sheet implementation (this) must distill available fields into description
   if (itemData[index.items.MAKE] && itemData[index.items.MODEL]) {
@@ -326,23 +326,23 @@ function makeItemFromDataGAS_(itemData) {
   } else {
     description = itemData[index.items.DESCRIPTION];
   }
-  
+
   item.setBarcode(itemData[index.items.BARCODE])
     .setSerialized()
     .setDescription(description)
     .setCheckedOut(itemData[index.items.CHECKED_OUT]);
-  
+
   return item;
 }
 
 function makeStudentFromDataGAS_(studentData) {
   var student = new Student_(studentData[index.students.ID]),
       signature = false;
-  
+
   if (studentData[index.students.SIGNATURE]) {
     signature = true;
   }
-  
+
   student.setName(studentData[index.students.NAME])
     .setNetId(studentData[index.students.NETID])
     .setSignatureOnFile(signature)
@@ -350,7 +350,7 @@ function makeStudentFromDataGAS_(studentData) {
   return student;
 }
 
-/********** WRITERS ************/
+/* ********* WRITERS *********** */
 
 /* exported writeCodabarGAS_ */
 function writeCodabarGAS_(netId, codabar) {
@@ -361,7 +361,12 @@ function writeCodabarGAS_(netId, codabar) {
   if (! i) {
     throw 'Could not match ' + netId;
   } else {
-    sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+    // check if a codabar already exists
+    if (data[i][0]){
+      throw 'The codabar for ' + data[i][1] + ' has already been set';
+    } else{
+      sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+    }
   }
 }
 

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -360,7 +360,7 @@ function makeStudentFromDataGAS_(studentData) {
 /* ********* WRITERS *********** */
 
 /* exported writeCodabarGAS_ */
-function writeCodabarGAS_(netId, codabar) {
+function writeCodabarGAS_(netId, codabar, update) {
   var sheet = SpreadsheetApp.openById(index.students.SHEET_ID)
     .getSheetByName(index.students.SHEET_NAME);
   var data = sheet.getDataRange().getValues();
@@ -368,21 +368,10 @@ function writeCodabarGAS_(netId, codabar) {
   if (typeof i == "undefined") {
     throw new Error ('Could not write codabar for ' + netId);
   }
-  sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
-}
-
-/* exported readCodabarGAS_ */
-function readCodabarGAS_(netId) {
-  var sheet = SpreadsheetApp.openById(index.students.SHEET_ID)
-    .getSheetByName(index.students.SHEET_NAME);
-  var data = sheet.getDataRange().getValues();
-  var i = data.findRowContaining(netId, index.students.NETID, true);
-  if (typeof i == "undefined") {
-    // the netId existed when the local machine checked app.cache, and must have been removed since then
-    throw new Error ('Could not find ' + netId);
-  } else {
-    return data[i][0];
+  if (data[i][index.students.id] && ! update) {
+    throw new Error("ID EXISTS");
   }
+  sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
 }
 
 function writeFormToSheetGAS_(form, closeAndArchive) {

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -359,14 +359,24 @@ function writeCodabarGAS_(netId, codabar) {
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(netId, index.students.NETID, true);
   if (! i) {
-    throw 'Could not match ' + netId;
+    // the the server called readCodabarGAS_, and the netId must have been removed since then
+    throw new Error ('Could not write codabar for ' + netId);
   } else {
-    // check if a codabar already exists
-    if (data[i][0]){
-      throw 'The codabar for ' + data[i][1] + ' has already been set';
-    } else{
-      sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
-    }
+    sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+  }
+}
+
+/* exported readCodabarGAS_ */
+function readCodabarGAS_(netId) {
+  var sheet = SpreadsheetApp.openById(index.students.SHEET_ID)
+    .getSheetByName(index.students.SHEET_NAME);
+  var data = sheet.getDataRange().getValues();
+  var i = data.findRowContaining(netId, index.students.NETID, true);
+  if (! i) {
+    // the netId existed when the local machine checked app.cache, and must have been removed since then
+    throw new Error ('Could not find ' + netId);
+  } else {
+    return data[i][0];
   }
 }
 

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -28,13 +28,38 @@ app.doCommand = function(command,...options) {
         JSON.parse(app.pages.form.elements.form.notes.value)
       );
       break;
+    case 'overwriteCodabar':
+      // calls the codabar funciton again, but now with overwrite set to true, so it will run the last if statement
+      app.doCommand('codabar', app.modal.tmp[0], app.modal.tmp[1], true);
+      break;
     case 'codabar':
-      // NetID is sitting in app.modal.input
-      // new codabar is sitting in omnibox AND app.modal.tmp
-      // need to update Students sheet and then parse omnibox
-      app.run.doPost({
-        post: 'codabar', netId: app.modal.getInput(), codabar: app.modal.tmp
-      });
+      // saves the netId submitted in the modal into app.modal.tmp so that it can be used later without being reset
+      app.modal.tmp[0] = app.modal.getInput();
+      // if the input netId does not match any netID in cache, throw an error and break
+      if (!app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])){
+        app.modal.handleError(new Error("NetID not Found"));
+        break;
+      }
+      // if there is already a codabar registered for that netId and we
+      // haven't confirmed overwrite, pull up the overwrite confirmation modal
+      if ((app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])).id && !options[2]){
+        app.modal.confirmOverwriteCodabar(app.modal.tmp[0], app.modal.tmp[1]);
+        break;
+      }
+      // if we are here, the netId must exist and there must not be a codabar registered to it OR overwrite must be enabled
+      // if overwrite is not enabled, try to write the codabar
+      if (!options[2]){
+        app.run.doPost({
+          post: 'codabar', netId: app.modal.tmp[0], codabar: app.modal.tmp[1], overwrite: false
+        });
+      }
+      // if overwrite is enabled, take the values passed from app.doCommand('overwriteCodabar')
+      // and try to write the codabar with the overwrite flag enabled
+      if (options[2]){
+        app.run.doPost({
+          post: 'codabar', netId: options[0], codabar: options[1], overwrite: true
+        });
+      }
       break;
     case 'displayForm': {
       const form = options[0],

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -28,38 +28,34 @@ app.doCommand = function(command,...options) {
         JSON.parse(app.pages.form.elements.form.notes.value)
       );
       break;
-    case 'overwriteCodabar':
-      // calls the codabar funciton again, but now with overwrite set to true, so it will run the last if statement
-      app.doCommand('codabar', app.modal.tmp[0], app.modal.tmp[1], true);
+    case 'codabar': {
+      const codabar = app.modal.tmp,
+            netId = app.modal.getInput(),
+            update = options[0] || false;
+      const student = app.cache.students.find(
+        student => student.netId.toLowerCase() == netId
+      );
+      if (! student){
+        app.modal.handleError(new Error(
+          "Oops, NetID " + netId + " did not match a current student. " +
+          "Refreshing the browser may help, or submit a trouble report."
+        ));
+        break;
+      }
+      if (student.id && ! update) {
+        app.modal.confirmUpdateCodabar(netId, codabar);
+        break;
+      }
+      app.run.doPost({
+        post: 'codabar',
+        netId,
+        codabar,
+        update: update
+      });
       break;
-    case 'codabar':
-      // saves the netId submitted in the modal into app.modal.tmp so that it can be used later without being reset
-      app.modal.tmp[0] = app.modal.getInput();
-      // if the input netId does not match any netID in cache, throw an error and break
-      if (!app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])){
-        app.modal.handleError(new Error("NetID not Found"));
-        break;
-      }
-      // if there is already a codabar registered for that netId and we
-      // haven't confirmed overwrite, pull up the overwrite confirmation modal
-      if ((app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])).id && !options[2]){
-        app.modal.confirmOverwriteCodabar(app.modal.tmp[0], app.modal.tmp[1]);
-        break;
-      }
-      // if we are here, the netId must exist and there must not be a codabar registered to it OR overwrite must be enabled
-      // if overwrite is not enabled, try to write the codabar
-      if (!options[2]){
-        app.run.doPost({
-          post: 'codabar', netId: app.modal.tmp[0], codabar: app.modal.tmp[1], overwrite: false
-        });
-      }
-      // if overwrite is enabled, take the values passed from app.doCommand('overwriteCodabar')
-      // and try to write the codabar with the overwrite flag enabled
-      if (options[2]){
-        app.run.doPost({
-          post: 'codabar', netId: options[0], codabar: options[1], overwrite: true
-        });
-      }
+    }
+    case 'codabarUpdateOK':
+      app.doCommand('codabar', true);
       break;
     case 'displayForm': {
       const form = options[0],

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -46,6 +46,7 @@ app.doCommand = function(command,...options) {
         app.modal.confirmUpdateCodabar(netId, codabar);
         break;
       }
+      app.spinner.inside(app.pages.form.elements.updateFormButton);
       app.run.doPost({
         post: 'codabar',
         netId,

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -37,8 +37,9 @@ app.doCommand = function(command,...options) {
       );
       if (! student){
         app.modal.handleError(new Error(
-          "Oops, NetID " + netId + " did not match a current student. " +
-          "Refreshing the browser may help, or submit a trouble report."
+          "Hmmm, NetID " + netId + " does not match a current student. " +
+          "Check that it was entered correctly, try refreshing the browser, " +
+          "or submit a trouble report."
         ));
         break;
       }

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -42,8 +42,6 @@ app.handlers = {
         --app.cache.currentIndex;
       }
     }
-    if (click.target.value == 'checkCodabar') {
-    }
     app.doCommand(click.target.value);
   },
   keydown: function(keydown) {

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -42,6 +42,8 @@ app.handlers = {
         --app.cache.currentIndex;
       }
     }
+    if (click.target.value == 'checkCodabar') {
+    }
     app.doCommand(click.target.value);
   },
   keydown: function(keydown) {

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -33,10 +33,12 @@ app.modal = {
                "message in error, choose \"close\".",
       ok:      "Submit",
     },
-    overwriteCodabar: {
-      heading: "Confirm Codabar Overwrite",
-      body:    "",
-      ok:      "Overwrite",
+    updateCodabar: {
+      heading: "Confirm Codabar Update",
+      body:    "Whoa- There is another ID already registered to that NetID. " +
+               "If you are sure you are updating their ID, " +
+               "click \"Update\", otherwise click \"Close\".",
+      ok:      "Update",
     },
     collision: {
       heading: "Uh-oh, your form conflicts with another form",
@@ -190,21 +192,18 @@ app.modal = {
     app.modal.setStrings('codabar');
     app.modal.ok.setAttribute('value', 'codabar');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.input);
-    // saves codabar into index 1 of modal.tmp so that netId can be saved into index 0 after clicking ok
-    app.modal.tmp = [null, codabar];
+    app.modal.tmp = codabar;
   },
 
-  confirmOverwriteCodabar: function(netId, codabar /* strings */) {
-    app.modal.blurAllTextInputs();
-    app.modal.setStrings('overwriteCodabar');
-    app.modal.body.textContent = 'There is already a codabar registered to ' +
-                                 app.cache.students.find(student => student.netId
-                                   .toLowerCase() == netId).name + '. If you ' +
-                                 'would like to overwrite it with a new one,' +
-                                 ' click "Overwrite", otherwise click "Close".';
-    app.modal.ok.setAttribute('value', 'overwriteCodabar');
-    app.modal.show(app.modal.container, app.modal.ok);
-    app.modal.tmp = [netId, codabar];
+  confirmUpdateCodabar: function(netId, codabar /* strings */) {
+    const m = app.modal;
+    m.blurAllTextInputs();
+    m.setStrings('updateCodabar');
+    m.ok.TextContent += " " + netId;
+    m.ok.setAttribute('value', 'codabarUpdateOK');
+    m.input.value = netId;
+    m.tmp = codabar;
+    m.show(app.modal.container, app.modal.ok);
   },
   getNote: function() {
     app.modal.setStrings('note');

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -33,6 +33,11 @@ app.modal = {
                "message in error, choose \"close\".",
       ok:      "Submit",
     },
+    overwriteCodabar: {
+      heading: "Confirm Codabar Overwrite",
+      body:    "",
+      ok:      "Overwrite",
+    },
     collision: {
       heading: "Uh-oh, your form conflicts with another form",
       body:    "Unfortunately, no automatic fix is available. Please write down " +
@@ -180,14 +185,27 @@ app.modal = {
   },
 
   getNewCodabar: function(codabar /* string */) {
-    app.modal.tmp = codabar;
     app.modal.input.setAttribute('placeholder', "enter student's NetID");
     app.modal.blurAllTextInputs();
     app.modal.setStrings('codabar');
     app.modal.ok.setAttribute('value', 'codabar');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.input);
+    // saves codabar into index 1 of modal.tmp so that netId can be saved into index 0 after clicking ok
+    app.modal.tmp = [null, codabar];
   },
 
+  confirmOverwriteCodabar: function(netId, codabar /* strings */) {
+    app.modal.blurAllTextInputs();
+    app.modal.setStrings('overwriteCodabar');
+    app.modal.body.textContent = 'There is already a codabar registered to ' +
+                                 app.cache.students.find(student => student.netId
+                                   .toLowerCase() == netId).name + '. If you ' +
+                                 'would like to overwrite it with a new one,' +
+                                 ' click "Overwrite", otherwise click "Close".';
+    app.modal.ok.setAttribute('value', 'overwriteCodabar');
+    app.modal.show(app.modal.container, app.modal.ok);
+    app.modal.tmp = [netId, codabar];
+  },
   getNote: function() {
     app.modal.setStrings('note');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.textarea);

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -29,13 +29,13 @@ app.modal = {
     codabar: {
       heading: "ID not recognized",
       body:    "If you scanned an ID, add it to the student's info by " +
-               "submitting their NetID.  If you think are seeing this " +
+               "submitting their NetID.  If you think you are seeing this " +
                "message in error, choose \"close\".",
       ok:      "Submit",
     },
     updateCodabar: {
-      heading: "Confirm Codabar Update",
-      body:    "Whoa- There is another ID already registered to that NetID. " +
+      heading: "Add new ID",
+      body:    "Whoa - there is another ID already registered to that NetID. " +
                "If you are sure you are updating their ID, " +
                "click \"Update\", otherwise click \"Close\".",
       ok:      "Update",
@@ -199,7 +199,8 @@ app.modal = {
     const m = app.modal;
     m.blurAllTextInputs();
     m.setStrings('updateCodabar');
-    m.ok.TextContent += " " + netId;
+    m.ok.textContent += " " + netId;
+    m.heading.textContent += " for " + netId + "?";
     m.ok.setAttribute('value', 'codabarUpdateOK');
     m.input.value = netId;
     m.tmp = codabar;

--- a/js/app/Refresh.html
+++ b/js/app/Refresh.html
@@ -70,6 +70,7 @@ app.refresh = function(response, context) {
     case 'codabar':
       app.cache.students = JSON.parse(response.students);
       app.modal.hide();
+      app.pages.form.elements.updateFormButton.textContent = "Update";
       app.omnibox.parse();
       break;
     case 'collision':


### PR DESCRIPTION
When a codabar is scanned and is not registed with a student/netID, prompt the
user to type a netID to associate the codabar with. If the netID is
already associated with a codabar, ask the user if they want to
overwrite.

Throws errors when the netID cannot be found in the sheet, and when a
codabar is associated with a netID in the sheet but not in app.cache
(in the case that another user registered a codabar with that netID
since the current user's last refresh)

fixes issue #70