### PR TITLE
fix: reject new student notes and global notes if they are blank

### DIFF
--- a/gs/Main.js
+++ b/gs/Main.js
@@ -9,6 +9,7 @@ getArchivedFormsGAS_
 getOpenFormsGAS_
 startSignature_
 writeCodabarGAS_
+readCodabarGAS_
 writeFormToSheetGAS_
 writeSignatureToSheetGAS_
 */
@@ -99,7 +100,7 @@ function doPost(request) {
   // to update wasn't already updated by someone else.
   switch (request.post) {
     case 'codabar':
-      postCodabar_(request.netId, request.codabar);
+      postCodabar_(request.netId, request.codabar, request.overwrite);
       response.students = getAllStudents_();
       break;
     case 'signature':
@@ -300,8 +301,16 @@ function isValidForm_(form) {
   return form;
 }
 
-function postCodabar_(netId, codabar) {
-  writeCodabarGAS_(netId, codabar);
+function postCodabar_(netId, codabar, overwrite) {
+  var oldCodabar = readCodabarGAS_(netId);
+  // if there isn't an old codabar, a codabar has been created since the creation of app.cache
+  // and shares the same value as the incoming change, or an overwrite has been approved
+  if (oldCodabar == '' || oldCodabar == codabar || overwrite){
+    writeCodabarGAS_(netId, codabar);
+  } else {
+    // there must be an old codabar registered that wasn't registed when app.cache was created
+    throw new Error ('Codabar could not be written. Please save your form, refresh your browser, and try again');
+  }
 }
 
 /** @see doPost */

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -6,7 +6,7 @@ utility
 Item_
 Student_
 */
-/********** GLOBAL VARIABLES ************/
+/* ********* GLOBAL VARIABLES *********** */
 var index = {
   bookings: {
     SHEET_ID   : '1zl4FBglYgCdR_FMdfbIQOOpnt9b8TwgnjxzRwcekPrY',
@@ -112,7 +112,7 @@ function checkItemsGAS_(form) {
   return form;
 }
 
-/********** CREATORS ************/
+/* ********* CREATORS *********** */
 
 /**
  * Loops createBookingFormGAS_ for each daily booking
@@ -138,7 +138,7 @@ function createBookingFormGAS_(booking) {
       itemStringArray = booking.getItems(),
       items = [],
       studentStringArray,
-      students = []; 
+      students = [];
 
   // handle booking students -> form students
   studentStringArray = bookedStudents.replace(/, /g, ',').split(',');
@@ -149,7 +149,7 @@ function createBookingFormGAS_(booking) {
     );
     students.push(makeStudentFromDataGAS_(data));
   });
-  
+
   // handle booking items -> form items
   if (itemStringArray) {
     itemStringArray = itemStringArray.split(',');
@@ -170,7 +170,7 @@ function createBookingFormGAS_(booking) {
       }
     });
   }
-  
+
   form.setBookedStudents(bookedStudents)
     .setBookingId(booking.getId())
     .setItems(items)
@@ -181,13 +181,13 @@ function createBookingFormGAS_(booking) {
     .setTape(booking.getTape())
     .setProject(booking.getProject())
     .setStudents(students);
-  
+
   writeFormToSheetGAS_(form);
-  
+
   return form;
 }
 
-/********** GETTERS ************/
+/* ********* GETTERS *********** */
 
 /* exported getAllItemsGAS_ */
 function getAllItemsGAS_() {
@@ -271,7 +271,7 @@ function getSheetDataByIdGAS_(value, sheetId, sheetName, idIndex) {
   return data.findRowContaining(value, idIndex);
 }
 
-/********** MAKERS ************/
+/* ********* MAKERS *********** */
 
 /**
  * @param {[]} bookingData
@@ -279,7 +279,7 @@ function getSheetDataByIdGAS_(value, sheetId, sheetName, idIndex) {
  */
 function makeBookingFromDataGAS_(bookingData) {
   var booking = new Booking_(bookingData[index.bookings.ID]);
-  
+
   booking.setBookedStudents(bookingData[index.bookings.STUDENTS])
     .setItems(bookingData[index.bookings.ITEMS])
     .setStartTime(utility.date.getFormattedDate(bookingData[index.bookings.START_TIME]))
@@ -288,17 +288,17 @@ function makeBookingFromDataGAS_(bookingData) {
     .setContact(bookingData[index.bookings.CONTACT])
     .setTape(bookingData[index.bookings.TAPE])
     .setProject(bookingData[index.bookings.PROJECT]);
-  
+
   return booking;
 }
 
-/** @param {object []} sheetData - a row pulled from Forms Sheet */ 
+/** @param {object []} sheetData - a row pulled from Forms Sheet */
 function makeFormFromDataGAS_(sheetData) {
   var form = new Form_(sheetData[index.forms.ID]),
       studentInfo = JSON.parse(sheetData[index.forms.STUDENTS]),
       itemsInfo = JSON.parse(sheetData[index.forms.ITEMS]),
       notes = JSON.parse(sheetData[index.forms.NOTES]);
-  
+
   form.setBookingId(sheetData[index.forms.BOOKING_ID])
     .setBookedStudents(sheetData[index.forms.BOOKED_STUDENTS])
     .setItems(itemsInfo)
@@ -311,14 +311,14 @@ function makeFormFromDataGAS_(sheetData) {
     .setStudents(studentInfo)
     .setNotes(notes)
     .setHash();
-  
+
   return form;
 }
 
 function makeItemFromDataGAS_(itemData) {
   var item = new Item_(itemData[index.items.ID]),
       description;
-  
+
   // Item has only a simple 'description' field
   // Sheet implementation (this) must distill available fields into description
   if (itemData[index.items.MAKE] && itemData[index.items.MODEL]) {
@@ -326,23 +326,23 @@ function makeItemFromDataGAS_(itemData) {
   } else {
     description = itemData[index.items.DESCRIPTION];
   }
-  
+
   item.setBarcode(itemData[index.items.BARCODE])
     .setSerialized()
     .setDescription(description)
     .setCheckedOut(itemData[index.items.CHECKED_OUT]);
-  
+
   return item;
 }
 
 function makeStudentFromDataGAS_(studentData) {
   var student = new Student_(studentData[index.students.ID]),
       signature = false;
-  
+
   if (studentData[index.students.SIGNATURE]) {
     signature = true;
   }
-  
+
   student.setName(studentData[index.students.NAME])
     .setNetId(studentData[index.students.NETID])
     .setSignatureOnFile(signature)
@@ -350,7 +350,7 @@ function makeStudentFromDataGAS_(studentData) {
   return student;
 }
 
-/********** WRITERS ************/
+/* ********* WRITERS *********** */
 
 /* exported writeCodabarGAS_ */
 function writeCodabarGAS_(netId, codabar) {
@@ -361,7 +361,12 @@ function writeCodabarGAS_(netId, codabar) {
   if (! i) {
     throw 'Could not match ' + netId;
   } else {
-    sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+    // check if a codabar already exists
+    if (data[i][0]){
+      throw 'The codabar for ' + data[i][1] + ' has already been set';
+    } else{
+      sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+    }
   }
 }
 

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -359,14 +359,24 @@ function writeCodabarGAS_(netId, codabar) {
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(netId, index.students.NETID, true);
   if (! i) {
-    throw 'Could not match ' + netId;
+    // the the server called readCodabarGAS_, and the netId must have been removed since then
+    throw new Error ('Could not write codabar for ' + netId);
   } else {
-    // check if a codabar already exists
-    if (data[i][0]){
-      throw 'The codabar for ' + data[i][1] + ' has already been set';
-    } else{
-      sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
-    }
+    sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
+  }
+}
+
+/* exported readCodabarGAS_ */
+function readCodabarGAS_(netId) {
+  var sheet = SpreadsheetApp.openById(index.students.SHEET_ID)
+    .getSheetByName(index.students.SHEET_NAME);
+  var data = sheet.getDataRange().getValues();
+  var i = data.findRowContaining(netId, index.students.NETID, true);
+  if (! i) {
+    // the netId existed when the local machine checked app.cache, and must have been removed since then
+    throw new Error ('Could not find ' + netId);
+  } else {
+    return data[i][0];
   }
 }
 

--- a/html/Form.html
+++ b/html/Form.html
@@ -19,7 +19,7 @@
       <div class="focusGuardTop" tabindex="0"></div>
       <input class="omnibox" type="text" placeholder="Scan ID or barcode" autocomplete="off"/>
       <button class="action buttonSmall" value="parseOmnibox" tabindex="-1">&#128269;</button>
-      <button class="action" value="manualItem" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
+      <button class="action" value="manualItem" tabindex="-1">Add item without barcode or ID</button>
       <button class="action buttonNotes" value="newNote" tabindex="-1">New Note</button>
       <button value="changeLog" tabindex="-1">Change Log</button>
       <br />

--- a/html/Form.html
+++ b/html/Form.html
@@ -73,8 +73,8 @@
               <option value="Edit Suite 2 509">Edit Suite 2 509</option>
               <option value="Lab 502">Lab 502</option>
               <option value="Lobby/Hallway">Lobby/Hallway</option>
-              <option value="Other">Other</option>
-              <option value="Studio 21 North" class="hidden"></option>
+              <option value="OtherSelector">Other</option>
+              <option value="Other" class="hidden"></option>
             </select>
           </td>
         </tr>

--- a/js/Display.html
+++ b/js/Display.html
@@ -365,7 +365,7 @@ function populateItemList(item) {
   if (! item.checkIn && ! item.serialized) {
     const id = item.id ? item.id : item.barcode;
     checkInButton = `<button class="action"
-                             value="parseOmnibox"
+                             value="checkInButton"
                              data-itemid="${id}">Check In</button>`;
   }
   if (item.missing == true) {

--- a/js/Logic.html
+++ b/js/Logic.html
@@ -82,7 +82,7 @@ function isCheckOutStudentOk(student) {
 /* exported isFormOkToPost */
 function isFormOkToPost() {
   let elements = app.pages.form.elements;
-  if (elements.locationSelect.value == 'none') {
+  if (elements.locationSelect.value == 'none' || elements.locationSelect.value == '') {
     return false;
   }
   if (elements.form.startTime.value == elements.form.endTime.value) {

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -28,13 +28,38 @@ app.doCommand = function(command,...options) {
         JSON.parse(app.pages.form.elements.form.notes.value)
       );
       break;
+    case 'overwriteCodabar':
+      // calls the codabar funciton again, but now with overwrite set to true, so it will run the last if statement
+      app.doCommand('codabar', app.modal.tmp[0], app.modal.tmp[1], true);
+      break;
     case 'codabar':
-      // NetID is sitting in app.modal.input
-      // new codabar is sitting in omnibox AND app.modal.tmp
-      // need to update Students sheet and then parse omnibox
-      app.run.doPost({
-        post: 'codabar', netId: app.modal.getInput(), codabar: app.modal.tmp
-      });
+      // saves the netId submitted in the modal into app.modal.tmp so that it can be used later without being reset
+      app.modal.tmp[0] = app.modal.getInput();
+      // if the input netId does not match any netID in cache, throw an error and break
+      if (!app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])){
+        app.modal.handleError(new Error("NetID not Found"));
+        break;
+      }
+      // if there is already a codabar registered for that netId and we
+      // haven't confirmed overwrite, pull up the overwrite confirmation modal
+      if ((app.cache.students.find(student => student.netId.toLowerCase() == app.modal.tmp[0])).id && !options[2]){
+        app.modal.confirmOverwriteCodabar(app.modal.tmp[0], app.modal.tmp[1]);
+        break;
+      }
+      // if we are here, the netId must exist and there must not be a codabar registered to it OR overwrite must be enabled
+      // if overwrite is not enabled, try to write the codabar
+      if (!options[2]){
+        app.run.doPost({
+          post: 'codabar', netId: app.modal.tmp[0], codabar: app.modal.tmp[1], overwrite: false
+        });
+      }
+      // if overwrite is enabled, take the values passed from app.doCommand('overwriteCodabar')
+      // and try to write the codabar with the overwrite flag enabled
+      if (options[2]){
+        app.run.doPost({
+          post: 'codabar', netId: options[0], codabar: options[1], overwrite: true
+        });
+      }
       break;
     case 'displayForm': {
       const form = options[0],

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -176,7 +176,21 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
+    case 'checkInButton':
+      // if the item cannot be found on the saved form, and was therefore "just checked out", it will throw an error and break
+      if (!app.cache.savedForm.items.find(i => (i.barcode || i.id) == options[0])){
+        app.modal.handleError(new Error('This item was just checked-out.  Update or revert the form to continue.'));
+        break;
+      }
+      // drops the itemID or barcode into omnibox and then parses omnibox
+      app.omnibox.element.value = options[0];
+      app.omnibox.parse();
+      break;
     case 'manualItem':
+      // drops the special value for triggering manual entry into omnibox, then parses it.
+      app.omnibox.element.value = '10000';
+      app.omnibox.parse();
+      break;
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -243,6 +243,10 @@ app.doCommand = function(command,...options) {
                 value :otherLocation
               }
             };
+      if (otherLocation == ''){
+        app.modal.getLocation();
+      }
+      app.pages.form.elements.locationOtherOption.setAttribute('hidden', false);
       select.value = option.value = otherLocation;
       app.pages.form.handleChange(change);
       option.textContent = otherLocation; // must follow handleChange

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -212,7 +212,9 @@ app.doCommand = function(command,...options) {
       displayForm(app.cache.savedForm);
       break;
     case 'saveNote': {
-      utility.saveNote();
+      if (app.modal.textarea.value){
+        utility.saveNote();
+      }
       break;
     }
     case 'saveManual': {
@@ -290,7 +292,9 @@ app.doCommand = function(command,...options) {
         utility.DOM.empty(app.pages.form.elements.studentList);
         students.forEach(populateStudentList);
       } else if (value == "other") {
-        utility.saveNote(student.name + ": ");
+        if (app.modal.textarea.value){
+          utility.saveNote(student.name + ": ");
+        }
       }
       break;
     }

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -91,7 +91,7 @@ app.doCommand = function(command,...options) {
       let change = { target: { name: 'items' } };
       let value = utility.DOM.getRadioValue();
       if (value == 'other') {
-        const note = app.modal.getText();
+        const note = app.modal.getText().trim();
         if (! note) {
           return;
         }
@@ -212,7 +212,7 @@ app.doCommand = function(command,...options) {
       displayForm(app.cache.savedForm);
       break;
     case 'saveNote': {
-      if (app.modal.textarea.value){
+      if (app.modal.textarea.value.trim()){
         utility.saveNote();
       }
       break;
@@ -292,7 +292,7 @@ app.doCommand = function(command,...options) {
         utility.DOM.empty(app.pages.form.elements.studentList);
         students.forEach(populateStudentList);
       } else if (value == "other") {
-        if (app.modal.textarea.value){
+        if (app.modal.textarea.value.trim()){
           utility.saveNote(student.name + ": ");
         }
       }

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -25,9 +25,11 @@ app.handlers = {
     if (click.target.tagName != 'BUTTON') {
       return;
     }
-
+    // this runs the checkInButton doCommand which drops the itemid into omnibox
+    // if the item has been saved and then parses the omnibox
     if (click.target.dataset.itemid) {
-      app.omnibox.element.value = click.target.dataset.itemid;
+      app.doCommand('checkInButton', click.target.dataset.itemid);
+      return;
     }
 
     if (click.target.value.slice(0,9) == 'loseData_') {

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -332,6 +332,7 @@ app.modal = {
     const m = app.modal;
     m.blurAllTextInputs();
     m.ok.setAttribute('value', 'itemQuantity');
+    app.modal.input.setAttribute('placeholder', '');
     m.tmp = itemDescription;
     m.setStrings('itemQuantity');
     m.show(m.container, m.input, m.ok);

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -33,6 +33,11 @@ app.modal = {
                "message in error, choose \"close\".",
       ok:      "Submit",
     },
+    overwriteCodabar: {
+      heading: "Confirm Codabar Overwrite",
+      body:    "",
+      ok:      "Overwrite",
+    },
     collision: {
       heading: "Uh-oh, your form conflicts with another form",
       body:    "Unfortunately, no automatic fix is available. Please write down " +
@@ -180,14 +185,27 @@ app.modal = {
   },
 
   getNewCodabar: function(codabar /* string */) {
-    app.modal.tmp = codabar;
     app.modal.input.setAttribute('placeholder', "enter student's NetID");
     app.modal.blurAllTextInputs();
     app.modal.setStrings('codabar');
     app.modal.ok.setAttribute('value', 'codabar');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.input);
+    // saves codabar into index 1 of modal.tmp so that netId can be saved into index 0 after clicking ok
+    app.modal.tmp = [null, codabar];
   },
 
+  confirmOverwriteCodabar: function(netId, codabar /* strings */) {
+    app.modal.blurAllTextInputs();
+    app.modal.setStrings('overwriteCodabar');
+    app.modal.body.textContent = 'There is already a codabar registered to ' +
+                                 app.cache.students.find(student => student.netId
+                                   .toLowerCase() == netId).name + '. If you ' +
+                                 'would like to overwrite it with a new one,' +
+                                 ' click "Overwrite", otherwise click "Close".';
+    app.modal.ok.setAttribute('value', 'overwriteCodabar');
+    app.modal.show(app.modal.container, app.modal.ok);
+    app.modal.tmp = [netId, codabar];
+  },
   getNote: function() {
     app.modal.setStrings('note');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.textarea);

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -15,6 +15,7 @@ app.pages.form = {
     itemList:                document.querySelector('tbody.itemList'),
     locationSelect:          document.querySelector('form.model select[name="location"]'),
     locationOtherOption:     document.querySelector('form.model option[value="Other"]'),
+    locationOtherSelector:   document.querySelector('form.model option[value="OtherSelector"]'),
     newNoteButton:           document.querySelector('button[value="newNote"]'),
     manualButton:            document.querySelector('button[value="manualItem"]'),
     omniboxButton:           document.querySelector('button[value="parseOmnibox"]'),
@@ -94,7 +95,8 @@ app.pages.form = {
     }
   },
   handleChangeLocation: function(change) {
-    if (change.target.value == 'Other') {
+    if (change.target.value == 'OtherSelector') {
+      app.pages.form.elements.locationOtherOption.setAttribute('hidden', true);
       change.target.value = 'none'; // in case the modal is cancelled
       app.modal.getLocation();
     } else { // it's not other, make sure 'Other' label is reset, log the change


### PR DESCRIPTION
checks the contents of the modal textarea after submitting a new student
note or global note, and does nothing if the textarea was left blank

also trims the whitespace on either side of new global notes, student notes, and item notes

fixes issue #74