### PR TITLE
fix: Disable the non-serialized/manual item check-in button until the form has been saved

### DIFF
--- a/html/Form.html
+++ b/html/Form.html
@@ -19,7 +19,7 @@
       <div class="focusGuardTop" tabindex="0"></div>
       <input class="omnibox" type="text" placeholder="Scan ID or barcode" autocomplete="off"/>
       <button class="action buttonSmall" value="parseOmnibox" tabindex="-1">&#128269;</button>
-      <button class="action" value="manualItem" data-itemid="10000" tabindex="-1">Add item without barcode or ID</button>
+      <button class="action" value="manualItem" tabindex="-1">Add item without barcode or ID</button>
       <button class="action buttonNotes" value="newNote" tabindex="-1">New Note</button>
       <button value="changeLog" tabindex="-1">Change Log</button>
       <br />

--- a/js/Display.html
+++ b/js/Display.html
@@ -365,7 +365,7 @@ function populateItemList(item) {
   if (! item.checkIn && ! item.serialized) {
     const id = item.id ? item.id : item.barcode;
     checkInButton = `<button class="action"
-                             value="parseOmnibox"
+                             value="checkInButton"
                              data-itemid="${id}">Check In</button>`;
   }
   if (item.missing == true) {

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -151,7 +151,21 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
+    case 'checkInButton':
+      // if the item cannot be found on the saved form, and was therefore "just checked out", it will throw an error and break
+      if (!app.cache.savedForm.items.find(i => (i.barcode || i.id) == options[0])){
+        app.modal.handleError(new Error('This item was just checked-out.  Update or revert the form to continue.'));
+        break;
+      }
+      // drops the itemID or barcode into omnibox and then parses omnibox
+      app.omnibox.element.value = options[0];
+      app.omnibox.parse();
+      break;
     case 'manualItem':
+      // drops the special value for triggering manual entry into omnibox, then parses it.
+      app.omnibox.element.value = '10000';
+      app.omnibox.parse();
+      break;
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -151,16 +151,21 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
-    case 'checkInButton':
-      // if the item cannot be found on the saved form, and was therefore "just checked out", it will throw an error and break
-      if (!app.cache.savedForm.items.find(i => (i.barcode || i.id) == options[0])){
-        app.modal.handleError(new Error('This item was just checked-out.  Update or revert the form to continue.'));
+    case 'checkInButton': {
+      const itemID = options[0];
+      const savedItem = app.cache.savedForm.items.find(
+        item => (item.barcode || item.id) == itemID
+      );
+      if (! savedItem) {
+        app.modal.handleError(new Error("This item was just checked-out. " +
+          "Update or revert the form to continue."
+        ));
         break;
       }
-      // drops the itemID or barcode into omnibox and then parses omnibox
-      app.omnibox.element.value = options[0];
+      app.omnibox.element.value = itemID;
       app.omnibox.parse();
       break;
+    }
     case 'manualItem':
       // drops the special value for triggering manual entry into omnibox, then parses it.
       app.omnibox.element.value = '10000';

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -21,13 +21,18 @@ app.handlers = {
       app.handlers.unload();
     }
   },
+
+  /**
+   * @see js/app/DoCommand
+   * clickButton usually routes user actions to js.app.doCommand, sometimes
+   *   with some additional filitering/modifying here
+   */
   clickButton: function(click) {
     if (click.target.tagName != 'BUTTON') {
       return;
     }
-    // this runs the checkInButton doCommand which drops the itemid into omnibox
-    // if the item has been saved and then parses the omnibox
-    if (click.target.dataset.itemid) {
+
+    if (click.target.value == "checkInButton") {
       app.doCommand('checkInButton', click.target.dataset.itemid);
       return;
     }

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -35,6 +35,9 @@ app.handlers = {
     if (click.target.value == "checkInButton") {
       app.doCommand('checkInButton', click.target.dataset.itemid);
       return;
+
+    if (click.target.dataset.itemid) {
+      app.omnibox.element.value = click.target.dataset.itemid;
     }
 
     if (click.target.value.slice(0,9) == 'loseData_') {

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -25,9 +25,11 @@ app.handlers = {
     if (click.target.tagName != 'BUTTON') {
       return;
     }
-
+    // this runs the checkInButton doCommand which drops the itemid into omnibox
+    // if the item has been saved and then parses the omnibox
     if (click.target.dataset.itemid) {
-      app.omnibox.element.value = click.target.dataset.itemid;
+      app.doCommand('checkInButton', click.target.dataset.itemid);
+      return;
     }
 
     if (click.target.value.slice(0,9) == 'loseData_') {

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -314,6 +314,7 @@ app.modal = {
     const m = app.modal;
     m.blurAllTextInputs();
     m.ok.setAttribute('value', 'itemQuantity');
+    app.modal.input.setAttribute('placeholder', '');
     m.tmp = itemDescription;
     m.setStrings('itemQuantity');
     m.show(m.container, m.input, m.ok);


### PR DESCRIPTION
clicking the check in buttons that sit in the "checked in" column of the
item table without first saving the item into the form will throw the
same error as attempting to check in a serialized item without first
saving it into the form.

Also refactors the manual entry button to use it's own doCommand case in
order to prevent the app from triggering the checkInButton handler when
clicking on the manual entry button

fixes issue #56