### PR TITLE
fix: prevents the location from being lost

### DIFF
--- a/html/Form.html
+++ b/html/Form.html
@@ -73,8 +73,8 @@
               <option value="Edit Suite 2 509">Edit Suite 2 509</option>
               <option value="Lab 502">Lab 502</option>
               <option value="Lobby/Hallway">Lobby/Hallway</option>
-              <option value="Other">Other</option>
-              <option value="Studio 21 North" class="hidden"></option>
+              <option value="OtherSelector">Other</option>
+              <option value="Other" class="hidden"></option>
             </select>
           </td>
         </tr>

--- a/js/Logic.html
+++ b/js/Logic.html
@@ -82,7 +82,7 @@ function isCheckOutStudentOk(student) {
 /* exported isFormOkToPost */
 function isFormOkToPost() {
   let elements = app.pages.form.elements;
-  if (elements.locationSelect.value == 'none') {
+  if (elements.locationSelect.value == 'none' || elements.locationSelect.value == '') {
     return false;
   }
   if (elements.form.startTime.value == elements.form.endTime.value) {

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -204,6 +204,10 @@ app.doCommand = function(command,...options) {
                 value :otherLocation
               }
             };
+      if (otherLocation == ''){
+        app.modal.getLocation();
+      }
+      app.pages.form.elements.locationOtherOption.setAttribute('hidden', false);
       select.value = option.value = otherLocation;
       app.pages.form.handleChange(change);
       option.textContent = otherLocation; // must follow handleChange

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -15,6 +15,7 @@ app.pages.form = {
     itemList:                document.querySelector('tbody.itemList'),
     locationSelect:          document.querySelector('form.model select[name="location"]'),
     locationOtherOption:     document.querySelector('form.model option[value="Other"]'),
+    locationOtherSelector:   document.querySelector('form.model option[value="OtherSelector"]'),
     newNoteButton:           document.querySelector('button[value="newNote"]'),
     manualButton:            document.querySelector('button[value="manualItem"]'),
     omniboxButton:           document.querySelector('button[value="parseOmnibox"]'),
@@ -94,7 +95,8 @@ app.pages.form = {
     }
   },
   handleChangeLocation: function(change) {
-    if (change.target.value == 'Other') {
+    if (change.target.value == 'OtherSelector') {
+      app.pages.form.elements.locationOtherOption.setAttribute('hidden', true);
       change.target.value = 'none'; // in case the modal is cancelled
       app.modal.getLocation();
     } else { // it's not other, make sure 'Other' label is reset, log the change


### PR DESCRIPTION
prevents the location from being set to the "none" option

prevents the location from being set to other where other is a
blank string

fixes a bug that caused the "Other" option in the location drop down
from holding on to the last set custom location, even in other forms,
until the browser was refreshed

fixes issue #13