### PR TITLE
fix: reject new student notes and global notes if they are blank

### DIFF
--- a/js/Utility.html
+++ b/js/Utility.html
@@ -326,11 +326,15 @@ utility.saveNote = function(prefix) {
   if (! prefix) {
     prefix = "";
   }
+  const input = app.modal.getText();
+  if (input.length < 1) {
+    return;
+  }
   const notes = JSON.parse(app.pages.form.elements.form.notes.value);
   const note = {
     timestamp: Date.now(),
     author: app.elements.usernameDisplay.textContent,
-    body: prefix + app.modal.getText(),
+    body: prefix + input,
   };
   let shortNotes = note.body;
   if (shortNotes.length > 10) {

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -66,7 +66,7 @@ app.doCommand = function(command,...options) {
       let change = { target: { name: 'items' } };
       let value = utility.DOM.getRadioValue();
       if (value == 'other') {
-        const note = app.modal.getText();
+        const note = app.modal.getText().trim();
         if (! note) {
           return;
         }
@@ -173,7 +173,9 @@ app.doCommand = function(command,...options) {
       displayForm(app.cache.savedForm);
       break;
     case 'saveNote': {
-      utility.saveNote();
+      if (app.modal.textarea.value.trim()){
+        utility.saveNote();
+      }
       break;
     }
     case 'saveManual': {
@@ -247,7 +249,9 @@ app.doCommand = function(command,...options) {
         utility.DOM.empty(app.pages.form.elements.studentList);
         students.forEach(populateStudentList);
       } else if (value == "other") {
-        utility.saveNote(student.name + ": ");
+        if (app.modal.textarea.value.trim()){
+          utility.saveNote(student.name + ": ");
+        }
       }
       break;
     }

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -66,8 +66,8 @@ app.doCommand = function(command,...options) {
       let change = { target: { name: 'items' } };
       let value = utility.DOM.getRadioValue();
       if (value == 'other') {
-        const note = app.modal.getText().trim();
-        if (! note) {
+        const note = app.modal.getText();
+        if (note.length < 1) {
           return;
         }
         change.target.value = description + " added note: " + note;
@@ -173,9 +173,7 @@ app.doCommand = function(command,...options) {
       displayForm(app.cache.savedForm);
       break;
     case 'saveNote': {
-      if (app.modal.textarea.value.trim()){
-        utility.saveNote();
-      }
+      utility.saveNote();
       break;
     }
     case 'saveManual': {
@@ -249,9 +247,7 @@ app.doCommand = function(command,...options) {
         utility.DOM.empty(app.pages.form.elements.studentList);
         students.forEach(populateStudentList);
       } else if (value == "other") {
-        if (app.modal.textarea.value.trim()){
-          utility.saveNote(student.name + ": ");
-        }
+        utility.saveNote(student.name + ": ");
       }
       break;
     }

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -219,7 +219,7 @@ app.modal = {
 
   // Interface for inputs, this is a private function, public calls getInput, getText
   getValueAndClear: function(inputElement) {
-    let value = inputElement.value;
+    let value = inputElement.value.trim();
     inputElement.value = '';
     return value;
   },


### PR DESCRIPTION
checks the contents of the modal textarea after submitting a new
student note or global note, and does nothing if the textarea was
left blank 

also trims the whitespace on either side of new global
notes, student notes, and item notes.

fixes issue #74