### PR TITLE
fix: unpacks JSON immediately, locks buttons if OK

### DIFF
--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -60,9 +60,10 @@ app.doCommand = function(command,...options) {
       app.doCommand('codabar', true);
       break;
     case 'collisionResolve': {
-      const form = JSON.parse(app.modal.tmp.storedForm);
+      const form = app.modal.tmp.storedForm;
       app.cache[app.cache.currentFormstack][app.cache.currentIndex] = form;
       app.changes.saved = true;
+      app.pages.form.lockButtons();
       displayForm(form);
       break;
     }

--- a/js/app/Refresh.html
+++ b/js/app/Refresh.html
@@ -74,6 +74,8 @@ app.refresh = function(response, context) {
       app.omnibox.parse();
       break;
     case 'collision':
+      response.storedForm = JSON.parse(response.storedForm);
+      response.submittedForm = JSON.parse(response.submittedForm);
       app.modal.handleError(response);
       app.pages.form.elements.updateFormButton.textContent = "Update";
       break;
@@ -108,9 +110,7 @@ app.refresh = function(response, context) {
       break;
     case 'updateForm': {
       app.changes.saved = true;
-      app.pages.form.elements.undoButton.setAttribute('disabled', true);
-      app.pages.form.elements.updateButtonHint.textContent = '';
-      app.pages.form.elements.updateFormButton.setAttribute('disabled', true);
+      app.pages.form.lockButtons();
       const updatedForm = JSON.parse(response.form);
       const index = app.cache.openForms.findIndex(
         (form) => (! form.id || form.id == updatedForm.id)

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -275,15 +275,11 @@ app.pages.form = {
     }
     app.modal.handleStudentNote(student);
   },
-  /* handleItemNoteInput: function(event) { // keydown.key == 'Enter' or blur
-    const value = event.target.value,
-          parent = event.target.parentNode;
-    const itemRow = parent.parentNode.previousSibling;
-    if (! itemRow) {
-      return;
-    }
-    app.doCommand('itemNote', itemRow.dataset.barcode,itemRow.dataset.id, value);
-  }, */
+  lockButtons: function() {
+    app.pages.form.elements.undoButton.setAttribute('disabled', true);
+    app.pages.form.elements.updateButtonHint.textContent = '';
+    app.pages.form.elements.updateFormButton.setAttribute('disabled', true);
+  },
   show: function() {
     app.pages.form.elements.container.classList.remove("hidden");
     if (isNaN(app.pages.form.timeoutId)) {


### PR DESCRIPTION
* two different Refresh cases:
  * a reject during "updateForm"
  * a reject while editing

* this commit makes sure both cases have the form
  JSON parsed immediately at refresh()

* also adds a helper function to js/app/pages/Form "lockButtons"
  since now both updateForm and collisionResolve cases need this
  same functionality