### PR TITLE
fix: removes manual item number from omnibox

### DIFF
--- a/html/Form.html
+++ b/html/Form.html
@@ -19,7 +19,7 @@
       <div class="focusGuardTop" tabindex="0"></div>
       <input class="omnibox" type="text" placeholder="Scan ID or barcode" autocomplete="off"/>
       <button class="action buttonSmall" value="parseOmnibox" tabindex="-1">&#128269;</button>
-      <button class="action" value="manualItem" tabindex="-1">Add item without barcode or ID</button>
+      <button class="action" value="newManual" tabindex="-1">Add item without barcode or ID</button>
       <button class="action buttonNotes" value="newNote" tabindex="-1">New Note</button>
       <button value="changeLog" tabindex="-1">Change Log</button>
       <br />

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -164,7 +164,6 @@ app.doCommand = function(command,...options) {
       app.modal.getNote();
       break;
     case 'newManual':
-      // TODO check if manual already exists
       app.modal.getManual();
       break;
     case 'nextForm':
@@ -197,10 +196,6 @@ app.doCommand = function(command,...options) {
       app.omnibox.parse();
       break;
     }
-    case 'manualItem':
-      app.omnibox.element.value = app.strings.manualItemBarcode;
-      app.omnibox.parse();
-      break;
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/Omnibox.html
+++ b/js/app/Omnibox.html
@@ -215,6 +215,7 @@ app.omnibox = {
         }
       } else if (barcoderegex.test(value)) { // assume it's a barcode
         if (value == app.strings.manualItemBarcode) {
+          app.omnibox.clear();
           app.doCommand("newManual");
           return;
         }

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -16,7 +16,7 @@ app.pages.form = {
     locationSelect:          document.querySelector('form.model select[name="location"]'),
     locationOtherOption:     document.querySelector('form.model option[value="Other"]'),
     newNoteButton:           document.querySelector('button[value="newNote"]'),
-    manualButton:            document.querySelector('button[value="manualItem"]'),
+    manualButton:            document.querySelector('button[value="newManual"]'),
     omniboxButton:           document.querySelector('button[value="parseOmnibox"]'),
     noteSection:             document.querySelector('section.globalnotes'),
     studentList:             document.querySelector('tbody.studentList'),


### PR DESCRIPTION
* manual item button bypasses omnibox completely, never leaving magic
  number in the box
* barcode scanning the magic number: parse function will clear out the
  omnibox once magic number detected.

fixes issue #82