### PR TITLE
fix: toast item description if no item id

### DIFF
--- a/js/app/Omnibox.html
+++ b/js/app/Omnibox.html
@@ -27,7 +27,7 @@ app.omnibox = {
     const change = { // fake change event
       target: {
         name: 'items',
-        value: item.id
+        value: item.id ? item.id : item.description
       }
     };
 


### PR DESCRIPTION
current behavior: if no item ID (generic item) then no toast message.
This will toast the item description if no ID is found.