### PR TITLE
feat: partial check in for items with quantity > 1

### DIFF
--- a/js/Display.html
+++ b/js/Display.html
@@ -265,6 +265,14 @@ function populateItemList(item) {
     checkInButton = `<button class="action"
                              value="checkInButton"
                              data-itemid="${id}">Check In</button>`;
+    if (item.quantity > 1) {
+      checkInButton += `<select data-itemid="${id}" class="selectQuantity">
+        <option value="all">All</option>`;
+      for (let i = 1; i < item.quantity; ++i) {
+        checkInButton += `<option>${i}</option>`;
+      }
+      checkInButton += `</select>`;
+    }
   }
   if (item.missing == true) {
     checkIn = `<span class="alert">ITEM IS MISSING</span>`;

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -27,6 +27,25 @@ app.doCommand = function(command,...options) {
         JSON.parse(app.pages.form.elements.form.notes.value)
       );
       break;
+    case 'checkInButton': {
+      const itemID = options[0];
+      const savedItem = app.cache.savedForm.items.find(
+        item => (item.barcode || item.id) == itemID
+      );
+      if (! savedItem) {
+        app.modal.handleError(new Error("This item was just checked-out. " +
+          "Update or revert the form to continue."
+        ));
+        break;
+      }
+      let quantityToReturn;
+      if (savedItem.quantity > 1) {
+        const quantityInput = document.querySelector(`select[data-itemid="${itemID}"]`);
+        quantityToReturn = quantityInput.value;
+      }
+      app.omnibox.handleItem(savedItem, quantityToReturn);
+      break;
+    }
     case 'codabar': {
       const codabar = app.modal.tmp,
             netId = app.modal.getInput(),
@@ -180,21 +199,6 @@ app.doCommand = function(command,...options) {
       app.spinner.on();
       app.run.doGet({ get: 'openForms' });
       break;
-    case 'checkInButton': {
-      const itemID = options[0];
-      const savedItem = app.cache.savedForm.items.find(
-        item => (item.barcode || item.id) == itemID
-      );
-      if (! savedItem) {
-        app.modal.handleError(new Error("This item was just checked-out. " +
-          "Update or revert the form to continue."
-        ));
-        break;
-      }
-      app.omnibox.element.value = itemID;
-      app.omnibox.parse();
-      break;
-    }
     case 'parseOmnibox':
       app.omnibox.parse();
       break;

--- a/js/app/Omnibox.html
+++ b/js/app/Omnibox.html
@@ -13,7 +13,7 @@ app.omnibox = {
   },
   element: document.querySelector('input.omnibox'),
   /** TODO - handle qty input or multiple scans of things like cables */
-  handleItem: function(item) {
+  handleItem: function(item, quantityToReturn) {
     const items = (JSON.parse(app.pages.form.elements.form.items.value) || []);
     const itemOnForm = items.find(i => {
       if (item.id && i.id == item.id) {
@@ -27,7 +27,9 @@ app.omnibox = {
     const change = { // fake change event
       target: {
         name: 'items',
-        value: item.id ? item.id : item.description
+        value: (item.id && ! /^manual/i.test(item.id))
+          ? item.id
+          : item.description
       }
     };
 
@@ -35,6 +37,9 @@ app.omnibox = {
       item.checkOut = utility.date.getFormattedDate(new Date());
       items.push(item);
       change.target.value += ' check-out';
+    } else if (quantityToReturn && quantityToReturn != "all") {
+      itemOnForm.quantity -= quantityToReturn;
+      change.target.value = `returned ${quantityToReturn} ${change.target.value}`;
     } else {
       if (itemOnForm.checkOut && itemOnForm.checkIn) { // checkout again?
         app.modal.handleError(

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -46,6 +46,10 @@ app.pages.form = {
   },
   /** for form validation and attach beforeunload listener for unsaved changes */
   handleChange: function(change) {
+    if (change.target.classList &&
+        change.target.classList.contains("selectQuantity")) {
+      return;
+    }
     app.changes.saved = false;
     app.pages.form.elements.undoButton.removeAttribute('disabled');
     if (!app.pages.form.elements.form.id) {


### PR DESCRIPTION
* adds dropdown next to check in button when quantity > 1
* adds guard in js/app/pages/Form change handler to ignore the new quantity
dropdown
* (fix) check in button bypasses omnibox parse and goes straight to item
handler

fixes issue #107