### PR TITLE
fix: removes unnecessary codabar confirmation

### DIFF
--- a/gs/Main.js
+++ b/gs/Main.js
@@ -306,19 +306,10 @@ function isValidForm_(form) {
 }
 
 /**
- * @param {obj} request - .netId{string}, .codabar{string}, .update{bool}
+ * @param {obj} request - .netId{string}, .codabar{string}
  */
 function postCodabar_(request) {
-  try {
-    writeCodabarGAS_(request.netId, request.codabar, request.update);
-  } catch (error) {
-    if (/ID EXISTS/.test(error)) {
-      throw new Error("Oops, we have another ID saved for " + request.netId +
-        ". Trying refreshing your browser."
-      );
-    }
-    throw error;
-  }
+  writeCodabarGAS_(request.netId, request.codabar);
 }
 
 /** @see doPost */

--- a/gs/Sheets.js
+++ b/gs/Sheets.js
@@ -362,16 +362,13 @@ function makeStudentFromDataGAS_(studentData) {
 /* ********* WRITERS *********** */
 
 /* exported writeCodabarGAS_ */
-function writeCodabarGAS_(netId, codabar, update) {
+function writeCodabarGAS_(netId, codabar) {
   var sheet = SpreadsheetApp.openById(index.students.SHEET_ID)
     .getSheetByName(index.students.SHEET_NAME);
   var data = sheet.getDataRange().getValues();
   var i = data.findRowContaining(netId, index.students.NETID, true);
   if (typeof i == "undefined") {
     throw new Error ('Could not write codabar for ' + netId);
-  }
-  if (data[i][index.students.id] && ! update) {
-    throw new Error("ID EXISTS");
   }
   sheet.getRange(i + 1, index.students.ID + 1).setValue(codabar);
 }

--- a/js/app/DoCommand.html
+++ b/js/app/DoCommand.html
@@ -48,8 +48,7 @@ app.doCommand = function(command,...options) {
     }
     case 'codabar': {
       const codabar = app.modal.tmp,
-            netId = app.modal.getInput(),
-            update = options[0] || false;
+            netId = app.modal.getInput();
       const student = app.cache.students.find(
         student => student.netId.toLowerCase() == netId
       );
@@ -61,22 +60,14 @@ app.doCommand = function(command,...options) {
         ));
         break;
       }
-      if (student.id && ! update) {
-        app.modal.confirmUpdateCodabar(netId, codabar);
-        break;
-      }
       app.spinner.inside(app.pages.form.elements.updateFormButton);
       app.run.doPost({
         post: 'codabar',
         netId,
         codabar,
-        update: update
       });
       break;
     }
-    case 'codabarUpdateOK':
-      app.doCommand('codabar', true);
-      break;
     case 'collisionResolve': {
       const form = app.modal.tmp.storedForm;
       app.cache[app.cache.currentFormstack][app.cache.currentIndex] = form;

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -29,13 +29,6 @@ app.modal = {
                "message in error, choose \"close\".",
       ok:      "Submit",
     },
-    updateCodabar: {
-      heading: "Add new ID",
-      body:    "Whoa - there is another ID already registered to that NetID. " +
-               "If you are sure you are updating their ID, " +
-               "click \"Update\", otherwise click \"Close\".",
-      ok:      "Update",
-    },
     collision: {
       heading: "Uh-oh, your form conflicts with another form",
       body:    "Unfortunately, no automatic fix is available, but your form " +
@@ -187,17 +180,6 @@ app.modal = {
     app.modal.tmp = codabar;
   },
 
-  confirmUpdateCodabar: function(netId, codabar /* strings */) {
-    const m = app.modal;
-    m.blurAllTextInputs();
-    m.setStrings('updateCodabar');
-    m.ok.textContent += " " + netId;
-    m.heading.textContent += " for " + netId + "?";
-    m.ok.setAttribute('value', 'codabarUpdateOK');
-    m.input.value = netId;
-    m.tmp = codabar;
-    m.show(app.modal.container, app.modal.ok);
-  },
   getNote: function() {
     app.modal.setStrings('note');
     app.modal.show(app.modal.container, app.modal.ok, app.modal.textarea);


### PR DESCRIPTION
* undoes some of PR #71 which introduced codabar confirmation
* app does not currently support blank codabars (ids) in student data,
see issue #116
* therefore, the ID/codabar field is always being overwritten, and the
check is not needed