### PR TITLE
fix: omnibox focus respects modal

### DIFF
--- a/js/Display.html
+++ b/js/Display.html
@@ -162,7 +162,6 @@ function displayForm(form, archived) {
       'You cannot edit it.';
   } else {
     app.omnibox.element.removeAttribute('disabled');
-    app.omnibox.element.focus();
     els.newNoteButton.removeAttribute('disabled');
     els.manualButton.removeAttribute('disabled');
     els.omniboxButton.removeAttribute('disabled');

--- a/js/app/Handlers.html
+++ b/js/app/Handlers.html
@@ -30,7 +30,7 @@ app.handlers = {
   checkLock: function(event) {
     if (app.pages.form.isShowing() &&
         app.pages.form.isLocked() &&
-        app.modal.container.classList.contains("hidden")) {
+        ! app.modal.isShowing()) {
       event.stopPropagation();
     }
   },
@@ -71,7 +71,7 @@ app.handlers = {
   keydown: function(keydown) {
     // Allow esc to safely exit error messages
     if (keydown.key == 'Escape') {
-      if (!app.modal.container.classList.contains('hidden')) {
+      if (app.modal.isShowing()) {
         app.modal.hide();
       } else {
         keydown.target.blur();
@@ -80,7 +80,7 @@ app.handlers = {
 
     // Allow cmd + enter to submit/update form
     if (! app.pages.form.elements.updateFormButton.disabled &&
-          app.modal.container.classList.contains('hidden')) {
+        ! app.modal.isShowing()) {
       if ((keydown.metaKey || keydown.ctrlKey) && keydown.key == 'Enter') {
         app.doCommand('updateForm');
         return;

--- a/js/app/Modal.html
+++ b/js/app/Modal.html
@@ -232,6 +232,10 @@ app.modal = {
     }
   },
 
+  isShowing: function () {
+    return ! app.modal.container.classList.contains("hidden");
+  },
+
   signatureReady: function() {
     let m = app.modal;
     m.setStrings('signatureReady');

--- a/js/app/pages/Form.html
+++ b/js/app/pages/Form.html
@@ -320,7 +320,9 @@ app.pages.form = {
     if (isNaN(app.pages.form.timeoutId)) {
       app.pages.form.setTimeout();
     }
-    app.omnibox.element.focus();
+    if (! app.modal.isShowing()) {
+      app.omnibox.element.focus();
+    }
   },
   timeoutId: NaN,
   unlock: function() {


### PR DESCRIPTION
* both the form `show` handler _and_ `displayForm` were calling
`omnibox.element.focus`
* gave modal a `.isShowing` function
* removed `displayForm` focus; focus happens on `show` and checks
`modal.isShowing` first